### PR TITLE
Added fix for block swapping elevators

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,9 +2,9 @@
 org.gradle.jvmargs=-Xmx5G
 # Fabric Properties
 # check these on https://fabricmc.net/develop/
-minecraft_version=26.1-pre-1
-loader_version=0.18.4
+minecraft_version=26.1.2
+loader_version=0.19.2
 # Mod Properties
-mod_version=2.1+26.1-pre-1
+mod_version=2.1+26.1.2
 maven_group=me.lukasabbe
 archives_base_name=CopperGratesBubbleThru

--- a/src/main/java/me/lukasabbe/coppergratesbubblethru/mixin/BubbleColumnBlockMixin.java
+++ b/src/main/java/me/lukasabbe/coppergratesbubblethru/mixin/BubbleColumnBlockMixin.java
@@ -26,7 +26,7 @@ public abstract class BubbleColumnBlockMixin {
     }
 
     @Shadow
-    public static void updateColumn(Block bubbleColumn, LevelAccessor level, BlockPos occupyAt, BlockState belowState) {
+    public static void updateColumn(Block bubbleColumn, LevelAccessor level, BlockPos occupyAt, BlockState occupyState, BlockState bubbleSource) {
     }
 
     @Shadow
@@ -78,11 +78,12 @@ public abstract class BubbleColumnBlockMixin {
                 waterPos.move(Direction.UP);
             }
             if(ModBlockTags.isAWaterLoggedCopperGrates(world.getBlockState(waterPos))){
-                updateColumn(bubbleColumn, world,waterPos.above(),world.getBlockState(waterPos));
+                BlockPos gratePos = waterPos.immutable();
+                updateColumn(bubbleColumn, world, gratePos, world.getBlockState(gratePos), world.getBlockState(gratePos.below()));
             }
 
+            ci.cancel();
         }
-        ci.cancel();
     }
 
     @ModifyExpressionValue(

--- a/src/main/java/me/lukasabbe/coppergratesbubblethru/mixin/MagmaBlockMixin.java
+++ b/src/main/java/me/lukasabbe/coppergratesbubblethru/mixin/MagmaBlockMixin.java
@@ -1,8 +1,8 @@
 package me.lukasabbe.coppergratesbubblethru.mixin;
 
-import me.lukasabbe.coppergratesbubblethru.tags.ModBlockTags;
+import me.lukasabbe.coppergratesbubblethru.util.GrateBubbleScheduler;
 import net.minecraft.core.BlockPos;
-import net.minecraft.core.Direction;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.MagmaBlock;
@@ -18,16 +18,14 @@ public class MagmaBlockMixin extends Block {
     }
 
     @Override
+    public void onPlace(@NotNull BlockState state, @NotNull Level level, @NotNull BlockPos pos, @NotNull BlockState oldState, boolean movedByPiston) {
+        super.onPlace(state, level, pos, oldState, movedByPiston);
+        GrateBubbleScheduler.scheduleColumnUpdateAboveGrates(level, pos);
+    }
+
+    @Override
     public void destroy(LevelAccessor level, BlockPos pos, @NotNull BlockState state) {
-        BlockPos.MutableBlockPos checkUp = pos.mutable().move(Direction.UP);
-        boolean aWaterLoggedCopperGrates = ModBlockTags.isAWaterLoggedCopperGrates(level.getBlockState(checkUp));
-        if(aWaterLoggedCopperGrates){
-            while (aWaterLoggedCopperGrates){
-                checkUp.move(Direction.UP);
-                aWaterLoggedCopperGrates = ModBlockTags.isAWaterLoggedCopperGrates(level.getBlockState(checkUp));
-            }
-            level.scheduleTick(checkUp,level.getBlockState(checkUp).getBlock(),0);
-        }
+        GrateBubbleScheduler.scheduleColumnUpdateAboveGrates(level, pos);
         super.destroy(level, pos, state);
     }
 }

--- a/src/main/java/me/lukasabbe/coppergratesbubblethru/mixin/SoulSandMixin.java
+++ b/src/main/java/me/lukasabbe/coppergratesbubblethru/mixin/SoulSandMixin.java
@@ -1,13 +1,14 @@
 package me.lukasabbe.coppergratesbubblethru.mixin;
 
-import me.lukasabbe.coppergratesbubblethru.tags.ModBlockTags;
+import me.lukasabbe.coppergratesbubblethru.util.GrateBubbleScheduler;
 import net.minecraft.core.BlockPos;
-import net.minecraft.core.Direction;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.SoulSandBlock;
 import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.state.BlockState;
+import org.jetbrains.annotations.NotNull;
 import org.spongepowered.asm.mixin.Mixin;
 
 @Mixin(SoulSandBlock.class)
@@ -17,16 +18,14 @@ public class SoulSandMixin extends Block {
     }
 
     @Override
+    public void onPlace(@NotNull BlockState state, @NotNull Level level, @NotNull BlockPos pos, @NotNull BlockState oldState, boolean movedByPiston) {
+        super.onPlace(state, level, pos, oldState, movedByPiston);
+        GrateBubbleScheduler.scheduleColumnUpdateAboveGrates(level, pos);
+    }
+
+    @Override
     public void destroy(LevelAccessor world, BlockPos pos, BlockState state) {
-        BlockPos.MutableBlockPos checkUp = pos.mutable().move(Direction.UP);
-        boolean aWaterLoggedCopperGrates = ModBlockTags.isAWaterLoggedCopperGrates(world.getBlockState(checkUp));
-        if(aWaterLoggedCopperGrates){
-            while (aWaterLoggedCopperGrates){
-                checkUp.move(Direction.UP);
-                aWaterLoggedCopperGrates = ModBlockTags.isAWaterLoggedCopperGrates(world.getBlockState(checkUp));
-            }
-            world.scheduleTick(checkUp,world.getBlockState(checkUp).getBlock(),0);
-        }
+        GrateBubbleScheduler.scheduleColumnUpdateAboveGrates(world, pos);
         super.destroy(world, pos, state);
     }
 }

--- a/src/main/java/me/lukasabbe/coppergratesbubblethru/util/GrateBubbleScheduler.java
+++ b/src/main/java/me/lukasabbe/coppergratesbubblethru/util/GrateBubbleScheduler.java
@@ -1,0 +1,29 @@
+package me.lukasabbe.coppergratesbubblethru.util;
+
+import me.lukasabbe.coppergratesbubblethru.tags.ModBlockTags;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.world.level.LevelAccessor;
+import net.minecraft.world.level.block.state.BlockState;
+
+public final class GrateBubbleScheduler {
+    private GrateBubbleScheduler() {
+    }
+
+    /**
+     * Schedules a block tick on the first non-grate block above {@code sourcePos},
+     * walking through any waterlogged copper grate stack. Used when a bubble source
+     * (magma / soul sand) is placed, removed, or replaced under grates.
+     */
+    public static void scheduleColumnUpdateAboveGrates(LevelAccessor level, BlockPos sourcePos) {
+        BlockPos.MutableBlockPos above = sourcePos.mutable().move(Direction.UP);
+        if (!ModBlockTags.isAWaterLoggedCopperGrates(level.getBlockState(above))) {
+            return;
+        }
+        while (ModBlockTags.isAWaterLoggedCopperGrates(level.getBlockState(above))) {
+            above.move(Direction.UP);
+        }
+        BlockState targetState = level.getBlockState(above);
+        level.scheduleTick(above, targetState.getBlock(), 0);
+    }
+}


### PR DESCRIPTION
Last patch I tried (1.21.8) worked great, this new one had an issue where block updates didn't update the bubbles through the grate. With this tweak now they do.

Should be reviewed and tested way more of course. Tested on 26.1.2. Should work on 26.1.X